### PR TITLE
Document homebrew bash dependency for completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,20 @@ export TRIXCTL_PASSWORD="secret"
 
 ### Bash Completion (Linux/Mac)
 
-Enable tab completion for faster command entry:
+Enable tab completion for faster command entry.
+
+**macOS Prerequisites:**
+macOS ships with an old bash version (3.2 from 2007). For best completion experience, install modern bash via Homebrew:
+
+```bash
+# Install modern bash and completion support
+brew install bash bash-completion@2
+
+# Add to your shell profile (~/.bash_profile or ~/.zshrc):
+export PATH="/opt/homebrew/bin:$PATH"
+```
+
+**Installation:**
 
 ```bash
 # System-wide installation (requires sudo):


### PR DESCRIPTION
## Summary
- Document macOS bash version limitation (3.2 from 2007 vs modern 5.x)
- Add homebrew installation instructions for modern bash
- Clarify why bash-completion@2 is recommended
- Provide clear setup instructions for macOS users

## Changes
- Updated README.md bash completion section with macOS prerequisites
- Added homebrew installation commands and PATH configuration
- Improved documentation structure with clear sections

## Test Plan
- [x] Verify documentation accuracy
- [x] Test bash completion with both system and homebrew bash
- [x] Validate installation instructions

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)